### PR TITLE
自定义文转图 HTML 模板

### DIFF
--- a/util/t2i/renderer.py
+++ b/util/t2i/renderer.py
@@ -12,7 +12,20 @@ class TextToImageRenderer:
         self.local_strategy = LocalRenderStrategy()
         self.context = RenderContext(self.network_strategy)
 
+    async def render_custom_template(self, tmpl_str: str, tmpl_data: dict, return_url: bool = False):
+        '''使用自定义文转图模板。该方法会通过网络调用 t2i 终结点图文渲染API。
+        @param tmpl_str: HTML Jinja2 模板。
+        @param tmpl_data: jinja2 模板数据。
+
+        @return: 图片 URL 或者文件路径，取决于 return_url 参数。
+
+        @example: 参见 https://astrbot.soulter.top 插件开发部分。
+        '''
+        await self.network_strategy.render_custom_template(**locals())
+
     async def render(self, text: str, use_network: bool = True, return_url: bool = False):
+        '''使用默认文转图模板。
+        '''
         if use_network:
             try:
                 return await self.context.render(text, return_url=return_url)

--- a/util/t2i/renderer.py
+++ b/util/t2i/renderer.py
@@ -21,7 +21,9 @@ class TextToImageRenderer:
 
         @example: 参见 https://astrbot.soulter.top 插件开发部分。
         '''
-        await self.network_strategy.render_custom_template(**locals())
+        local = locals()
+        local.pop('self')
+        return await self.network_strategy.render_custom_template(**local)
 
     async def render(self, text: str, use_network: bool = True, return_url: bool = False):
         '''使用默认文转图模板。

--- a/util/t2i/strategies/base_strategy.py
+++ b/util/t2i/strategies/base_strategy.py
@@ -5,3 +5,6 @@ class RenderStrategy(ABC):
     def render(self, text: str, return_url: bool) -> str:
         pass
     
+    @abstractmethod
+    def render_custom_template(self, tmpl_str: str, tmpl_data: dict, return_url: bool) -> str:
+        pass

--- a/util/t2i/strategies/local_strategy.py
+++ b/util/t2i/strategies/local_strategy.py
@@ -6,6 +6,9 @@ from PIL import ImageFont, Image, ImageDraw
 from util.io import save_temp_img
 
 class LocalRenderStrategy(RenderStrategy):
+
+    async def render_custom_template(self, tmpl_str: str, tmpl_data: dict, return_url: bool=True) -> str:
+        raise NotImplementedError
     
     def get_font(self, size: int) -> ImageFont.FreeTypeFont:
         # common and default fonts on Windows, macOS and Linux

--- a/util/t2i/strategies/network_strategy.py
+++ b/util/t2i/strategies/network_strategy.py
@@ -5,11 +5,33 @@ from .base_strategy import RenderStrategy
 from type.config import VERSION
 from util.io import download_image_by_url
 
+ASTRBOT_T2I_DEFAULT_ENDPOINT = "https://t2i.soulter.top/text2img"
+
 class NetworkRenderStrategy(RenderStrategy):
-    def __init__(self) -> None:
-        super().__init__()  
-        self.BASE_RENDER_URL = "https://t2i.soulter.top/text2img"
+    def __init__(self, base_url: str = ASTRBOT_T2I_DEFAULT_ENDPOINT) -> None:
+        super().__init__()
+        self.BASE_RENDER_URL = base_url
         self.TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "template")
+
+    async def render_custom_template(self, tmpl_str: str, tmpl_data: dict, return_url: bool=True) -> str:
+        '''使用自定义文转图模板'''
+        post_data = {
+            "tmpl": tmpl_str,
+            "json": return_url,
+            "tmpldata": tmpl_data,
+            "options": {
+                "full_page": True,
+                "type": "jpeg",
+                "quality": 40,
+            }
+        }
+        if return_url:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.BASE_RENDER_URL}/generate", json=post_data) as resp:
+                    ret = await resp.json()
+                    return f"{self.BASE_RENDER_URL}/{ret['data']['id']}"
+        return await download_image_by_url(f"{self.BASE_RENDER_URL}/generate", post=True, post_data=post_data)
+
 
     async def render(self, text: str, return_url: bool=False) -> str:
         '''
@@ -17,28 +39,6 @@ class NetworkRenderStrategy(RenderStrategy):
         '''
         with open(os.path.join(self.TEMPLATE_PATH, "base.html"), "r", encoding='utf-8') as f:
             tmpl_str = f.read()
-
         assert(tmpl_str)
-
         text = text.replace("`", "\`")
-
-        post_data = {
-            "tmpl": tmpl_str,
-            "json": return_url,
-            "tmpldata": {
-                "text": text,
-                "version": f"v{VERSION}",
-            },
-            "options": {
-                "full_page": True,
-                "type": "jpeg",
-                "quality": 40,
-            }
-        }
-        
-        if return_url:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self.BASE_RENDER_URL}/generate", json=post_data) as resp:
-                    ret = await resp.json()
-                    return f"{self.BASE_RENDER_URL}/{ret['data']['id']}"
-        return await download_image_by_url(f"{self.BASE_RENDER_URL}/generate", post=True, post_data=post_data)
+        return await self.render_custom_template(tmpl_str, {"text": text, "version": f"v{VERSION}"}, return_url)


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
实现了 #176

### Motivation

实现自定义文转图，更高的插件自由度。

### Modifications

修改了 util/t2i 包。

### 说明

AstrBot 使用 HTML + Jinja2 的方式来渲染文转图模板。

比如你可以自定义一个 HTML 模板：

```html
<h1 style="color: red">{{title}}</h1>

<p>{{content}}</p>
```

然后传递一个字典：
    
```py
{
    "title": "警报!",
    "content": "10 分钟后课程大作业截止！"
}
```

这样，AstrBot 就会按照这个 HTML 模板生成一张图片，图片内容为 `警报!` 和 `10 分钟后课程大作业截止！`。 

```py
TMPL = '''
<div style="font-size: 32px;"> 
<h1 style="color: red">{{title}}</h1>

<p>{{content}}</p>
</div>
'''
from util.plugin_dev.api.v1.bot import Context, AstrMessageEvent, CommandResult
from util.plugin_dev.api.v1.config import *

class HelloWorldPlugin:
    """
    AstrBot 会传递 context 给插件。
    
    - context.register_commands: 注册指令
    - context.register_task: 注册任务
    - context.message_handler: 消息处理器(平台类插件用)
    """
    def __init__(self, context: Context) -> None:
        self.context = context
        self.context.register_commands("helloworld", "helloworld", "内置测试指令。", 1, self.helloworld)

    """
    指令处理函数。
    
    - 需要接收两个参数：message: AstrMessageEvent, context: Context
    - 返回 CommandResult 对象
    """
    async def helloworld(self, message: AstrMessageEvent, context: Context):
        # return CommandResult().message("Hello, World!")
        url = await self.context.image_renderer.render_custom_template(TMPL, {
            "title": "警报！",
            "content": "10 分钟后课程大作业截止！"
        }, return_url=True)
    
        return CommandResult().url_image(url)
```

返回的结果:

![4100bf6e694a1cc9d4b9eb1a4a6b6dcd](https://github.com/user-attachments/assets/e71f0ad0-d3ed-4bfb-a28b-12c1b57b32f2)

> 这只是一个简单的例子。得益于 HTML 和 DOM 渲染器的强大性，你可以进行更复杂和更美观的的设计。除此之外，Jinja2 支持循环、条件等语法以适应列表、字典等数据结构。你可以从网上了解更多关于 Jinja2 的知识。
 
