### PR TITLE
fix: correct dashboard update tooltip typo

### DIFF
--- a/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
+++ b/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
@@ -28,7 +28,7 @@ const sidebarMenu = shallowRef(sidebarItems);
       </v-list-item>
       <small style="display: block;" v-if="buildVer">构建: {{ buildVer }}</small>
       <small style="display: block;" v-else>构建: embedded</small>
-      <v-tooltip text="使用 /dashbord_update 指令更新管理面板">
+      <v-tooltip text="使用 /dashboard_update 指令更新管理面板">
         <template v-slot:activator="{ props }">
           <small v-bind="props" v-if="hasWebUIUpdate" style="display: block; margin-top: 4px;">面板有更新</small>
         </template>


### PR DESCRIPTION
### Motivation

在管理面板的更新提示工具提示中，发现了一个拼写错误。原来的提示文本中"dashboard"被错误地拼写为"dashbord"，这需要被修正以保持专业性和准确性。

### Modifications

- 修正了VerticalSidebar.vue中更新提示工具提示的拼写错误
- 将 `/dashbord_update` 更正为 `/dashboard_update`