### PR TITLE
🐛 fix: 修复webchat未处理base64的问题

### DIFF
--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import base64
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import Plain, Image
@@ -31,6 +32,11 @@ class WebChatMessageEvent(AstrMessageEvent):
                     with open(path, "wb") as f:
                         with open(ph, "rb") as f2:
                             f.write(f2.read())
+                elif comp.file.startswith("base64://"):
+                    base64_str = comp.file[9:]
+                    image_data = base64.b64decode(base64_str)
+                    with open(path, "wb") as f:
+                        f.write(image_data)
                 elif comp.file and comp.file.startswith("http"):
                     await download_image_by_url(comp.file, path=path)
                 else:


### PR DESCRIPTION
### Motivation

webchat未处理base64，导致Image.fromBytes在webchat平台中出现问题

![8bc6ca9d70bb0d59f0533ec92bae0f7f](https://github.com/user-attachments/assets/e609c9d8-b5c7-42c6-b651-2def9fcbc3a4)


### Modifications

增加base64处理逻辑
