### PR TITLE
🐛fix: 修复aiocqhttp_platform_adapter文件相关判断逻辑

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -148,8 +148,11 @@ class AiocqhttpAdapter(Platform):
             a = None
             if t == 'text':
                 message_str += m['data']['text'].strip()
+                a = ComponentTypes[t](**m['data'])  # noqa: F405
+                abm.message.append(a)
+
             elif t == 'file':
-                if m['data']['url'] and m['data']['url'].startswith("http"):
+                if m['data'].get('url') and m['data'].get('url').startswith("http"):
                     # Lagrange
                     logger.info("guessing lagrange")
                     
@@ -161,6 +164,8 @@ class AiocqhttpAdapter(Platform):
                         "file": path,
                         "name": file_name
                     }
+                    a = ComponentTypes[t](**m['data'])  # noqa: F405
+                    abm.message.append(a)
                 
                 else:
                     try:
@@ -175,13 +180,17 @@ class AiocqhttpAdapter(Platform):
                             "file": ret['file'],
                             "name": ret['file_name']
                         }
+                        a = ComponentTypes[t](**m['data'])  # noqa: F405
+                        abm.message.append(a)
                     except ActionFailed as e:
                         logger.error(f"获取文件失败: {e}，此消息段将被忽略。")
                     except BaseException as e:
                         logger.error(f"获取文件失败: {e}，此消息段将被忽略。")
-                    
-            a = ComponentTypes[t](**m['data'])  # noqa: F405
-            abm.message.append(a)
+                        
+            else:        
+                a = ComponentTypes[t](**m['data'])  # noqa: F405
+                abm.message.append(a)
+
         abm.timestamp = int(time.time())
         abm.message_str = message_str
         abm.raw_message = event

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -187,7 +187,7 @@ class AiocqhttpAdapter(Platform):
                     except BaseException as e:
                         logger.error(f"获取文件失败: {e}，此消息段将被忽略。")
                         
-            else:        
+            else:
                 a = ComponentTypes[t](**m['data'])  # noqa: F405
                 abm.message.append(a)
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #586

### Motivation

![Image](https://github.com/user-attachments/assets/4a709e36-fcb5-495f-b74c-bff0812292f3)

这里的切片会报KeyError导致判断没办法进行下去

![Image](https://github.com/user-attachments/assets/b8f7e1d0-ad09-4d21-9f29-889ecde17660)


获取文件失败会导致传入未预期的参数file_id

![Image](https://github.com/user-attachments/assets/83608409-66e9-4bb4-8d3d-8c6114731413)

### Modifications

修改切片为`get`方法

将`a = ComponentTypes[t](**m['data'])`和`abm.message.append(a)`的调用移到了各个具体的分支内，然后添加了`else`分支处理其他类型的消息
