### PR TITLE
🐛 fix: 修复telegram适配器中未处理base64的问题

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -40,8 +40,15 @@ class TelegramPlatformEvent(AstrMessageEvent):
                     image_path = i.path
                 else:
                     image_path = i.file
-                await client.send_photo(photo=image_path, **payload)
-        
+
+                if image_path.startswith("base64://"):
+                    import base64
+                    base64_data = image_path[9:]
+                    image_bytes = base64.b64decode(base64_data)
+                    await client.send_photo(photo=image_bytes, **payload)
+                else:
+                    await client.send_photo(photo=image_path, **payload)
+
     async def send(self, message: MessageChain):
         if self.get_message_type() == MessageType.GROUP_MESSAGE:
             await self.send_with_client(self.client, message, self.message_obj.group_id)


### PR DESCRIPTION
修复了 #613

### Motivation

telegram适配器中未处理base64，导致Image.fromBytes在telegram平台中出现问题
![image](https://github.com/user-attachments/assets/7543ecfe-58c0-4575-a42f-bfdd5fb9c0da)

### Modifications

将base64转为bytes后发送
