### PR TITLE
修改为工具函数调用前的请求不被加入到上下文

### DIFF
--- a/packages/astrbot/long_term_memory.py
+++ b/packages/astrbot/long_term_memory.py
@@ -119,11 +119,11 @@ class LongTermMemory:
         
         if self.enable_active_reply:
             prompt = req.prompt
-            req.prompt = f"You are now in a chatroom. The chat history is as follows:\n{chats_str}"
+            req.prompt = f"\n\nYou are now in a chatroom. The chat history is as follows:\n{chats_str}"
             req.prompt += f"\nNow, a new message is coming: `{prompt}`. Please react to it. Only output your response and do not output any other information."
             req.contexts = [] # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:
-            req.system_prompt += "You are now in a chatroom. The chat history is as follows: \n"
+            req.system_prompt += "\n\nYou are now in a chatroom. The chat history is as follows: \n"
             req.system_prompt += chats_str
             
     async def after_req_llm(self, event: AstrMessageEvent):


### PR DESCRIPTION
### Motivation
修改前，工具函数调用前会将请求加入上下文，导致如果调用工具函数，上下文长度过长；修改后，只有会生成最终结果的请求会加入上下文

### Modifications

- LLM请求函数执行逻辑
- 长期记忆提示词添加换行