### PR TITLE
fix bug #621

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -75,7 +75,7 @@ class AiocqhttpAdapter(Platform):
         else:
             abm.type = MessageType.FRIEND_MESSAGE
         if self.unique_session and abm.type == MessageType.GROUP_MESSAGE:
-            abm.session_id = abm.sender.user_id + "_" + str(event.group_id)
+            abm.session_id = str(abm.sender.user_id) + "_" + str(event.group_id)
         abm.message_str = ''
         abm.message = []
         abm.timestamp = int(time.time())


### PR DESCRIPTION
修复了 #621

### Motivation
OneBot V11 通知类事件某些情况会无法回复问题

astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py 中：
async def convert_handle_notice_event(self, event: Event) -> AstrBotMessage:
出错行：abm.session_id = abm.sender.user_id + "" + str(event.group_id)

### Modifications

将出错行改为abm.session_id = str(abm.sender.user_id) + "_" + str(event.group_id)
