### PR TITLE
将Flask初始化时允许的最大文件体积设置为128MB

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -23,6 +23,7 @@ class AstrBotDashboard():
         self.config = core_lifecycle.astrbot_config
         self.data_path = os.path.abspath(os.path.join(DATAPATH, "dist"))
         self.app = Quart("dashboard", static_folder=self.data_path, static_url_path="/")
+        self.app.config['MAX_CONTENT_LENGTH'] = 128 * 1024 * 1024  # 将Flask允许的最大上传文件体大小设置为128MB
         self.app.json.sort_keys = False
         self.app.before_request(self.auth_middleware)
         # token 用于验证请求


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #无法从webui直接载入体积超过16MB的插件的bug

### Motivation
当从webui的插件市场中选择从本地zip加载插件时，需要经过dashboard程序，但是Flask初始化时最大只允许传输16MB大小的文件体，导致尝试载入比如anka的meme插件<https://github.com/anka-afk/astrbot_plugin_meme_manager>（大小为70.4MB）时会返回错误：
```
werkzeug exceptions.RequestEntityTooLarge: 413 Request Entity Too Large: Thedata value transmitted exceeds the capacity limit.
```
同时这种包体积太大导致通过Git安装在dashboard也很容易返回443超时，然后看群里有群友整了一下午加一晚上没安装上www。

### Modifications

在`astrbot/dashboard/server.py`中的`Line26`添加了对于`dashboard`初始化时允许的最大文件体体积设置，调整为128MB。
