### PR TITLE
Update aiocqhttp_platform_adapter.py

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -140,7 +140,7 @@ class AiocqhttpAdapter(Platform):
             abm.type = MessageType.FRIEND_MESSAGE
         if self.unique_session and abm.type == MessageType.GROUP_MESSAGE:
             abm.session_id = (
-                abm.sender.user_id + "_" + str(event.group_id)
+                str(abm.sender.user_id) + "_" + str(event.group_id)
             )  # 也保留群组 id
         else:
             abm.session_id = (

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -308,7 +308,9 @@ class PluginManager:
                                     context=self.context
                                 )
                         else:
-                            metadata.star_cls = metadata.star_cls_type(context=self.context)
+                            metadata.star_cls = metadata.star_cls_type(
+                                context=self.context
+                            )
                     else:
                         logger.info(f"插件 {metadata.name} 已被禁用。")
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 这里int不能和str组成新字符串的问题

### Motivation

<!--解释为什么要改动-->
报错 int 不能与 str 进行 '+' 操作

### Modifications

<!--简单解释你的改动-->
就是int -> str(int)

`abm.sender.user_id + "_" + str(event.group_id)
`
改为
`str(abm.sender.user_id) + "_" + str(event.group_id)
`
