### PR TITLE
fix: 修复个人微信非第一次登陆情况，已记录gewechat的appid失效设备不存在导致无法重新登陆个人微信的bug

### DIFF
--- a/astrbot/core/pipeline/whitelist_check/stage.py
+++ b/astrbot/core/pipeline/whitelist_check/stage.py
@@ -51,7 +51,10 @@ class WhitelistCheckStage(Stage):
                 and event.get_message_type() == MessageType.FRIEND_MESSAGE
             ):
                 return
-        if event.unified_msg_origin not in self.whitelist and event.get_group_id() not in self.whitelist:
+        if (
+            event.unified_msg_origin not in self.whitelist
+            and event.get_group_id() not in self.whitelist
+        ):
             if self.wl_log:
                 logger.info(
                     f"会话 ID {event.unified_msg_origin} 不在会话白名单中，已终止事件传播。请在配置文件中添加该会话 ID 到白名单。"

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -309,32 +309,47 @@ class SimpleGewechatClient:
         )
 
         if self.appid:
-            online = await self.check_online(self.appid)
-            if online:
-                logger.info(f"APPID: {self.appid} 已在线")
-                return
+            try:
+                online = await self.check_online(self.appid)
+                if online:
+                    logger.info(f"APPID: {self.appid} 已在线")
+                    return
+            except Exception as e:
+                logger.error(f"检查在线状态失败: {e}")
+                sp.put(f"gewechat-appid-{self.nickname}", "")
+                self.appid = None
 
         payload = {"appId": self.appid}
 
         if self.appid:
             logger.info(f"使用 APPID: {self.appid}, {self.nickname}")
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.base_url}/login/getLoginQrCode",
-                headers=self.headers,
-                json=payload,
-            ) as resp:
-                json_blob = await resp.json()
-                if json_blob["ret"] != 200:
-                    raise Exception(f"获取二维码失败: {json_blob}")
-                qr_data = json_blob["data"]["qrData"]
-                qr_uuid = json_blob["data"]["uuid"]
-                appid = json_blob["data"]["appId"]
-                logger.info(f"APPID: {appid}")
-                logger.warning(
-                    f"请打开该网址，然后使用微信扫描二维码登录: https://api.cl2wm.cn/api/qrcode/code?text={qr_data}"
-                )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.base_url}/login/getLoginQrCode",
+                    headers=self.headers,
+                    json=payload,
+                ) as resp:
+                    json_blob = await resp.json()
+                    if json_blob["ret"] != 200:
+                        error_msg = json_blob.get("data", {}).get("msg", "")
+                        if "设备不存在" in error_msg:
+                            logger.error(f"检测到无效的appid: {self.appid}，将清除并重新登录。")
+                            sp.put(f"gewechat-appid-{self.nickname}", "")
+                            self.appid = None
+                            return await self.login()
+                        else:
+                            raise Exception(f"获取二维码失败: {json_blob}")
+                    qr_data = json_blob["data"]["qrData"]
+                    qr_uuid = json_blob["data"]["uuid"]
+                    appid = json_blob["data"]["appId"]
+                    logger.info(f"APPID: {appid}")
+                    logger.warning(
+                        f"请打开该网址，然后使用微信扫描二维码登录: https://api.cl2wm.cn/api/qrcode/code?text={qr_data}"
+                    )
+        except Exception as e:
+            raise e
 
         # 执行登录
         retry_cnt = 64

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -335,7 +335,9 @@ class SimpleGewechatClient:
                     if json_blob["ret"] != 200:
                         error_msg = json_blob.get("data", {}).get("msg", "")
                         if "设备不存在" in error_msg:
-                            logger.error(f"检测到无效的appid: {self.appid}，将清除并重新登录。")
+                            logger.error(
+                                f"检测到无效的appid: {self.appid}，将清除并重新登录。"
+                            )
                             sp.put(f"gewechat-appid-{self.nickname}", "")
                             self.appid = None
                             return await self.login()

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -268,7 +268,10 @@ class Main(star.Star):
 UID: {user_id} 此 ID 可用于设置管理员。
 /op <UID> 授权管理员, /deop <UID> 取消管理员。"""
 
-        if self.context.get_config()["platform_settings"]["unique_session"] and event.get_group_id():
+        if (
+            self.context.get_config()["platform_settings"]["unique_session"]
+            and event.get_group_id()
+        ):
             ret += f"\n\n当前处于独立会话模式, 此群 ID: {event.get_group_id()}, 也可将此 ID 加入白名单来放行整个群聊。"
 
         event.set_result(MessageEventResult().message(ret).use_t2i(False))


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #765 #398

### Motivation

<!--解释为什么要改动-->
解决已记录gewechat的appid失效设备不存在的情况下，astrbot无法再次登陆个人微信的bug

### Modifications

<!--简单解释你的改动-->
修复完善astrbot/core/platform/sources/gewechat/client.py的相关登陆代码逻辑：

效果如下：
实测：
第二次登陆：
`2025-03-11T00:23:02.813318066+08:00  [00:23:02] [Core] [INFO] [gewechat.client:80]: 获取到 Gewechat Token: abcdefg 
2025-03-11T00:23:02.820156441+08:00  [00:23:02] [Core] [INFO] [gewechat.client:325]: 使用 APPID: wx_xxx, bba 
2025-03-11T00:23:02.832609063+08:00  [00:23:02] [Core] [ERRO] [gewechat.client:338]: 检测到无效的appid: wx_xxx，将清除并重新登录。 
2025-03-11T00:23:03.771755138+08:00  [00:23:03] [Core] [INFO] [gewechat.client:347]: APPID: wx_new_xxx 
2025-03-11T00:23:03.771877377+08:00  [00:23:03] [Core] [WARN] [gewechat.client:348]: 请打开该网址，然后使用微信扫描二维码登录: https://api.cl2wm.cn/api/qrcode/code?text=http://weixin.qq.com/x/wx_xxx `


重启容器：
`2025-03-11T00:24:22.180904793+08:00  [00:24:22] [Core] [INFO] [gewechat.client:80]: 获取到 Gewechat Token: abcdefg 
2025-03-11T00:24:22.187039606+08:00  [00:24:22] [Core] [INFO] [gewechat.client:315]: APPID: wx_new_xxx 已在线 `

问题解决
