### PR TITLE
fix: 修复gewechat平台用户本人发消息触发消息回复的bug

### DIFF
--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -147,6 +147,11 @@ class SimpleGewechatClient:
             abm.type = MessageType.FRIEND_MESSAGE
             user_id = from_user_name
 
+        # 检查消息是否由自己发送，若是则忽略
+        if user_id == abm.self_id:
+            logger.info("忽略自己发送的消息")
+            return None
+
         abm.message = []
         if at_me:
             abm.message.insert(0, At(qq=abm.self_id))


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #754

### Motivation

<!--解释为什么要改动-->
astrbot通过gewchat平台，无论是私聊还是群聊，当用户本人发出去消息时也会被机器人回复消息，这个不应该发生

### Modifications

<!--简单解释你的改动-->
client.py 设置过滤本人发出的消息即可。
