### PR TITLE
修复了使用Image.fromBytes等包装的图片消息链无法通过qq官方机器人适配器发送的bug

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -130,7 +130,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         "base64://", ""
                     )
                 else:
-                    image_base64 = file_to_base64(i.file).replace("base64://", "")
+                    image_base64 = i.file.replace("base64://", "")
                     image_file_path = i.file
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -122,16 +122,16 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 plain_text += i.text
             elif isinstance(i, Image) and not image_base64:
                 if i.file and i.file.startswith("file:///"):
-                    image_base64 = file_to_base64(i.file[8:]).replace("base64://", "")
+                    image_base64 = file_to_base64(i.file[8:])
                     image_file_path = i.file[8:]
                 elif i.file and i.file.startswith("http"):
                     image_file_path = await download_image_by_url(i.file)
-                    image_base64 = file_to_base64(image_file_path).replace(
-                        "base64://", ""
-                    )
+                    image_base64 = file_to_base64(image_file_path)
+                elif i.file and i.file.startswith("base64://"):
+                    image_base64 = i.file
                 else:
-                    image_base64 = i.file.replace("base64://", "")
-                    image_file_path = i.file
+                    image_base64 = file_to_base64(i.file)
+                image_base64 = image_base64.removeprefix("base64://")
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
         return plain_text, image_base64, image_file_path


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
这个问题还没有创建相关Issue

### Motivation
使用qq官方机器人适配器时,如果使用了 `Image.fromBytes`  `Image.fromBase64` 来组装包含图片的消息链,**消息会一直无法发出**,原因是适配器在bytes转换成base64后,错误的把base64内容传入`file_to_base64`函数,导致异步线程一直尝试从文件系统中读取不存在的路径,导致异步任务失败

报错信息大致如下:
![79ae07edc7ffddb1fbcbcd0a69d3b9e0](https://github.com/user-attachments/assets/102d117c-968a-40f4-8521-ec5d3509a45d)


### Modifications
`i.file`的内容就是url字符串,而`i.file`的头部不为`file:///`和`http`,那就剩下`base64://`了作为协议头部了吧
当协议头部是`base64://`时,直接吧字符串前面的url头部移除就能得到`image_base64`了,而不是这个url放进`file_to_base64`里处理
