### PR TITLE
修复命令参数报错信息无法发送至qq官方机器人平台的bug

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -106,6 +106,7 @@ class WakingCheckStage(Stage):
                             f"插件 {star_map[handler.handler_module_path].name}: {e}"
                         )
                     )
+                    await event._post_send()
                     event.stop_event()
                     passed = False
                     break
@@ -117,6 +118,7 @@ class WakingCheckStage(Stage):
                                 f"ID {event.get_sender_id()} 权限不足。通过 /sid 获取 ID 并请管理员添加。"
                             )
                         )
+                        await event._post_send()
                     event.stop_event()
                     return
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #806 

### Motivation

如题

### Modifications

在`event.stop_event`之前调用`event._post_send`将消息发送到消息平台,在此之前`event.stop_event`之后`event._post_send`未被调用从而导致 #806 的问题
