### PR TITLE
feat:新增MCP服务支持并优化工具调用逻辑

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -127,6 +127,9 @@ class ProviderManager:
         if self.tts_enabled and not self.curr_tts_provider_inst:
             logger.warning("未启用任何用于 文本转语音 的提供商适配器。")
 
+        # 初始化mcpclient连接
+        await self.llm_tools.init_mcp_client_list()
+
     async def load_provider(self, provider_config: dict):
         if not provider_config["enable"]:
             return

--- a/astrbot/core/provider/sources/llmtuner_source.py
+++ b/astrbot/core/provider/sources/llmtuner_source.py
@@ -85,7 +85,7 @@ class LLMTunerModelLoader(Provider):
             "system": system_prompt,
         }
         if func_tool:
-            tool_list = func_tool.get_func_desc_openai_style()
+            tool_list = await func_tool.get_func_desc_openai_style()
             if tool_list:
                 conf["tools"] = tool_list
 

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -80,7 +80,7 @@ class ProviderOpenAIOfficial(Provider):
 
     async def _query(self, payloads: dict, tools: FuncCall) -> LLMResponse:
         if tools:
-            tool_list = tools.get_func_desc_openai_style()
+            tool_list = await tools.get_func_desc_openai_style()
             if tool_list:
                 payloads["tools"] = tool_list
 
@@ -124,8 +124,10 @@ class ProviderOpenAIOfficial(Provider):
                 for tool in tools.func_list:
                     if tool.name == tool_call.function.name:
                         args = json.loads(tool_call.function.arguments)
-                        args_ls.append(args)
-                        func_name_ls.append(tool_call.function.name)
+                if tool_call.function.name.startswith("mcp:") and tool_call.function.name.split(':')[1] in tools.mcp_client_dict:
+                    args = json.loads(tool_call.function.arguments)
+                args_ls.append(args)
+                func_name_ls.append(tool_call.function.name)
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls
             llm_response.tools_call_name = func_name_ls

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,9 @@ psutil>=5.8.0
 lark-oapi
 ormsgpack
 cryptography
+
+mcp~=1.4.1
+anthropic~=0.49.0
 dashscope
 python-telegram-bot
 wechatpy


### PR DESCRIPTION
根据mcp开源官方案例引入MCP客户端支持，增加mcp_server.json配置样例，完善工具描述生成及调用逻辑以支持MCP服务工具功能。同时调整相关逻辑以区分本地工具与MCP工具的调用方式，提升扩展性和灵活性。

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
完成了 #843 

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->
增加了一个mcp client管理器，添加了相关依赖。添加了一个实例json。
在openai接口中简单的支持了mcp协议

### 效果
载入时日志
![image](https://github.com/user-attachments/assets/8122a675-59c2-4381-8d05-2a8738b5bcfb)

激活时日志
![image](https://github.com/user-attachments/assets/95d3b685-6dd8-4e43-aaf9-6795a24d20d4)
