### PR TITLE
将对只有一个 @ 的消息内容的处理改成调用llm回复

### DIFF
--- a/packages/session_controller/main.py
+++ b/packages/session_controller/main.py
@@ -1,5 +1,6 @@
 import astrbot.api.message_components as Comp
 import copy
+import json
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.star import Context, Star, register
@@ -54,8 +55,36 @@ class Waiter(Star):
                     isinstance(messages[0], Comp.Plain)
                     and messages[0].text.strip() in self.wake_prefix
                 ):
-                    yield event.plain_result("想要问什么呢？😄")
-
+                    try:
+                        # 尝试使用 LLM 生成更生动的回复
+                        func_tools_mgr = self.context.get_llm_tool_manager()
+                        
+                        # 获取用户当前的对话信息
+                        curr_cid = await self.context.conversation_manager.get_curr_conversation_id(event.unified_msg_origin)
+                        conversation = None
+                        context = []
+                        
+                        if curr_cid:
+                            conversation = await self.context.conversation_manager.get_conversation(event.unified_msg_origin, curr_cid)
+                            context = json.loads(conversation.history) if conversation.history else []
+                        else:
+                            # 创建新对话
+                            curr_cid = await self.context.conversation_manager.new_conversation(event.unified_msg_origin)
+                            
+                        # 使用 LLM 生成回复
+                        yield event.request_llm(
+                            prompt="用户只是@我或唤醒我，请友好地询问用户想要聊些什么或者需要什么帮助，回复要符合人设，不要太过机械化。",
+                            func_tool_manager=func_tools_mgr,
+                            session_id=curr_cid,
+                            contexts=context,
+                            system_prompt="",
+                            conversation=conversation
+                        )
+                    except Exception as e:
+                        logger.error(f"LLM response failed: {str(e)}")
+                        # LLM 回复失败，使用原始预设回复
+                        yield event.plain_result("想要问什么呢？😄")
+                    
                     @session_waiter(60)
                     async def empty_mention_waiter(
                         controller: SessionController, event: AstrMessageEvent
@@ -74,7 +103,16 @@ class Waiter(Star):
                     try:
                         await empty_mention_waiter(event)
                     except TimeoutError as _:
-                        yield event.plain_result("如果需要帮助，请再次 @ 我哦~")
+                        try:
+                            # 超时时也尝试使用 LLM 生成回复
+                            yield event.request_llm(
+                                prompt="用户在提问后超时未回复，请生成一个温馨友好的提醒，告诉用户如果需要帮助可以再次提问，回答要符合人设。",
+                                func_tool_manager=self.context.get_llm_tool_manager(),
+                                system_prompt=""
+                            )
+                        except Exception:
+                            # LLM 回复失败，使用原始预设回复
+                            yield event.plain_result("如果需要帮助，请再次 @ 我哦~")
                     except Exception as e:
                         yield event.plain_result("发生错误，请联系管理员: " + str(e))
                     finally:

--- a/packages/session_controller/main.py
+++ b/packages/session_controller/main.py
@@ -58,19 +58,29 @@ class Waiter(Star):
                     try:
                         # 尝试使用 LLM 生成更生动的回复
                         func_tools_mgr = self.context.get_llm_tool_manager()
-                        
+
                         # 获取用户当前的对话信息
-                        curr_cid = await self.context.conversation_manager.get_curr_conversation_id(event.unified_msg_origin)
+                        curr_cid = await self.context.conversation_manager.get_curr_conversation_id(
+                            event.unified_msg_origin
+                        )
                         conversation = None
                         context = []
-                        
+
                         if curr_cid:
-                            conversation = await self.context.conversation_manager.get_conversation(event.unified_msg_origin, curr_cid)
-                            context = json.loads(conversation.history) if conversation.history else []
+                            conversation = await self.context.conversation_manager.get_conversation(
+                                event.unified_msg_origin, curr_cid
+                            )
+                            context = (
+                                json.loads(conversation.history)
+                                if conversation.history
+                                else []
+                            )
                         else:
                             # 创建新对话
-                            curr_cid = await self.context.conversation_manager.new_conversation(event.unified_msg_origin)
-                            
+                            curr_cid = await self.context.conversation_manager.new_conversation(
+                                event.unified_msg_origin
+                            )
+
                         # 使用 LLM 生成回复
                         yield event.request_llm(
                             prompt="用户只是@我或唤醒我，请友好地询问用户想要聊些什么或者需要什么帮助，回复要符合人设，不要太过机械化。",
@@ -78,13 +88,13 @@ class Waiter(Star):
                             session_id=curr_cid,
                             contexts=context,
                             system_prompt="",
-                            conversation=conversation
+                            conversation=conversation,
                         )
                     except Exception as e:
                         logger.error(f"LLM response failed: {str(e)}")
                         # LLM 回复失败，使用原始预设回复
                         yield event.plain_result("想要问什么呢？😄")
-                    
+
                     @session_waiter(60)
                     async def empty_mention_waiter(
                         controller: SessionController, event: AstrMessageEvent
@@ -108,7 +118,7 @@ class Waiter(Star):
                             yield event.request_llm(
                                 prompt="用户在提问后超时未回复，请生成一个温馨友好的提醒，告诉用户如果需要帮助可以再次提问，回答要符合人设。",
                                 func_tool_manager=self.context.get_llm_tool_manager(),
-                                system_prompt=""
+                                system_prompt="",
                             )
                         except Exception:
                             # LLM 回复失败，使用原始预设回复


### PR DESCRIPTION
将对只有一个 @ 的消息内容的处理改成调用llm回复

### Motivation

原本预设好的文案非常生硬，很影响聊天。我认为改成调用llm可以使对只有一个 @ 的消息内容的处理的回复更个性化更生动

### Modifications

我将原本直接发送预设文案改成了通过预设的提示词调用llm，如果调用失败则发送预设的文案
