### PR TITLE
Telegram适配器消息处理功能增强

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -133,7 +133,11 @@ class TelegramPlatformAdapter(Platform):
         message.message_str = ""
         message.message = []
 
-        if update.message.reply_to_message:
+        if update.message.reply_to_message and not (
+            update.message.is_topic_message
+            and update.message.message_thread_id
+            == update.message.reply_to_message.message_id
+        ):
             # 获取回复消息
             reply_update = Update(
                 update_id=1,

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -199,6 +199,15 @@ class TelegramPlatformAdapter(Platform):
                         ]
                         message.message.append(Comp.At(qq=name, name=name))
 
+        elif update.message.sticker:
+            # 将sticker当作图片处理
+            file = await update.message.sticker.get_file()
+            message.message.append(Comp.Image(file=file.file_path, url=file.file_path))
+            if update.message.sticker.emoji:
+                sticker_text = f"Sticker: {update.message.sticker.emoji}"
+                message.message_str = sticker_text
+                message.message.append(Comp.Plain(sticker_text))
+
         elif update.message.document:
             file = await update.message.document.get_file()
             message.message = [

--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -69,10 +69,10 @@ class StatRoute(Route):
             process = psutil.Process()
             # 获取系统CPU使用率而不是进程CPU使用率
             cpu_percent = psutil.cpu_percent(interval=0.5)
-            
+
             # 获取线程数
             thread_count = threading.active_count()
-            
+
             # 获取插件信息
             plugins = self.core_lifecycle.star_context.get_all_stars()
             plugin_info = []
@@ -80,7 +80,7 @@ class StatRoute(Route):
                 info = {
                     "name": getattr(plugin, "name", plugin.__class__.__name__),
                     "version": getattr(plugin, "version", "1.0.0"),
-                    "is_enabled": True
+                    "is_enabled": True,
                 }
                 plugin_info.append(info)
 

--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -65,8 +65,6 @@ class StatRoute(Route):
 
             stat_dict = stat.__dict__
 
-            # 获取CPU使用率 - 修复CPU始终为0的问题
-            process = psutil.Process()
             # 获取系统CPU使用率而不是进程CPU使用率
             cpu_percent = psutil.cpu_percent(interval=0.5)
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #954

### Motivation

无法处理stickers

话题内正常消息被识别为回复消息

### Modifications

添加stickers处理逻辑

排除“回复话题首条消息”的情况
