### PR TITLE
fix: install_plugin_from_file 方法load传参数改为文件名

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -606,4 +606,4 @@ class PluginManager:
         except BaseException as e:
             logger.warning(f"删除插件压缩包失败: {str(e)}")
         # await self.reload()
-        await self.load(desti_dir)
+        await self.load(specified_dir_name=dir_name)


### PR DESCRIPTION
修复了 #995 

### Motivation
参数格式不正确影响后续判断

### Modifications
使用文件名作为插件名传参